### PR TITLE
add OctoAcme Project Management README with process overview and linksAdd files via upload

### DIFF
--- a/docs/docs_octoacme-project-management-readme_Version2.md
+++ b/docs/docs_octoacme-project-management-readme_Version2.md
@@ -1,0 +1,25 @@
+# OctoAcme Project Management Docs — README
+
+Welcome to the OctoAcme Project Management Documentation. This README provides a concise orientation to our approach, highlights key workflows and roles, and links to the process documents in this folder so contributors and stakeholders can quickly find the guidance they need.
+
+OctoAcme follows a structured, stage-gated lifecycle from Initiation through Planning, Execution, Release, and Retrospective. Initiation uses a lightweight Project One-pager to capture problem statements, success metrics, stakeholders, and initial risks to support go/no-go decisions. Planning turns approved initiatives into a prioritized backlog with estimates, a Definition of Done, and a release and milestone plan. Execution is iterative and board-driven (Backlog → Ready → In Progress → In Review → QA → Done), emphasizing small pull requests, automated CI gates, and frequent demos to reduce risk and accelerate feedback. Releases follow a checklist-driven flow with pre-release smoke tests, rollback plans, and formal release notes. Retrospectives after sprints or milestones capture learnings and create actionable improvements.
+
+Our workflows emphasize small, reviewable increments, automated checks, and explicit acceptance criteria. The pull request workflow requires issue links and acceptance criteria in PR descriptions, CI (tests/lint/security scans) passing before review, and at least one approver before merging. Testing includes unit tests, integration tests where applicable, and end-to-end smoke tests for critical flows; manual QA is used for acceptance testing when needed. Release guidance prescribes pre-release checklists, staging smoke tests, post-deploy verification, and an incident rollback playbook. Continuous improvement is driven by retrospective action items tracked in the backlog.
+
+Roles and communication are defined to ensure clear ownership and timely information flow. Core personas include Project Managers (coordinate delivery, schedules, risks, and communications), Product Managers (define outcomes and prioritize the backlog), Developers (implement and test), QA (validate acceptance criteria and quality), and Stakeholders (provide inputs and approvals). Communication is cadence-driven: daily standups, weekly delivery syncs, demo/reviews at the end of sprints or milestones, and monthly stakeholder updates. Risk reporting uses a living Risk Register and a weekly status template (progress, next steps, risks/blockers, asks). Escalation paths proceed from team triage → PM → Product Lead → Sponsor for business-impacting issues.
+
+How to use these docs
+- Start with this README for orientation.
+- Open the specific process docs below for templates, checklists, and step-by-step guidance.
+- Keep the Project One-pager, risk register, and key artifacts in the project repo so this knowledge is discoverable and versioned.
+- Propose edits using the "Add Content to Project Management Process Docs" issue template in .github/ISSUE_TEMPLATE/.
+
+Process Document Links
+- docs/octoacme-project-management-overview.md
+- docs/octoacme-project-initiation.md
+- docs/octoacme-project-planning.md
+- docs/octoacme-execution-and-tracking.md
+- docs/octoacme-risks-and-communication.md
+- docs/octoacme-release-and-deployment.md
+- docs/octoacme-retrospective-and-continuous-improvement.md
+- docs/octoacme-roles-and-personas.md


### PR DESCRIPTION
Short description: Adds docs/octoacme-project-management-readme.md with an overview of OctoAcme project management processes, key workflows, roles, communication cadence, QA practices, and links to the detailed docs in docs/.
Related issue: Related to #3
Checklist:
 README added to docs/
 Contains project management summary based on existing docs/
 Links to all docs/ files